### PR TITLE
Added configuration file

### DIFF
--- a/todotxt_machine/cli.py
+++ b/todotxt_machine/cli.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import argparse
+import ConfigParser
 import random
 
 from todotxt_machine.todo import Todos
@@ -11,38 +12,56 @@ from todotxt_machine.screen import Screen
 def main():
     random.seed()
 
-    # Default todo.txt file
-    todotxt_file = '~/Dropbox/todo/todo.txt'
-
     # Parse command line
     command_line = argparse.ArgumentParser(
         description = 'Interactive terminal interface for todo.txt files.')
     command_line.add_argument(
         '-f', '--file',
-        help    = 'path to your todo.txt file default:{0}'.format(todotxt_file),
-        default = todotxt_file)
+        help    = 'path to your todo.txt file. default: read from config file',
+        default = None)
     command_line.add_argument(
         '--readline-editing-mode',
         choices = ['emacs', 'vi'],
         help    = 'set readline editing-mode',
         default = 'vi')
+    command_line.add_argument(
+        '-c', '--config',
+        help    = 'path to your todotxt-machine configuraton file default:$(default)s',
+        default = '~/.todotxt-machinerc'
+    )
 
     args = command_line.parse_args()
+    todotxt_file = args.file
 
-    todotxt_file_path = os.path.expanduser(args.file)
+    # Parse config file
+    cfg = ConfigParser.ConfigParser()
+    cfg.read(os.path.expanduser(args.config))
+    if todotxt_file is None and cfg.has_section('files') and cfg.has_option('files', 'todo'):
+        todotxt_file = cfg.get('files', 'todo')
+
+    if todotxt_file is None:
+        sys.stderr.write("ERROR: No todo file specified. Either specify one as command line argument or set it in"
+                         "your configuartion directory!")
+        exit(1)
+
+    # expand enviroment variables and username, get canonical path
+    todotxt_file_path = os.path.realpath(os.path.expanduser(os.path.expandvars(todotxt_file)))
 
     print("Opening: {0}".format(todotxt_file_path))
 
-    if os.path.exists(todotxt_file_path):
-        pass
-    else:
-        directory = os.path.dirname(os.path.realpath(todotxt_file_path))
-        if os.path.exists(directory):
-            pass
+    if os.path.isdir(todotxt_file_path):
+        sys.stderr.write("ERROR: Specified todo file is a directory.")
+        exit(1)
+
+    if not os.path.exists(todotxt_file_path):
+        directory = os.path.dirname(todotxt_file_path)
+        if os.path.isdir(directory):
+            # directory exists, but no todo.txt file - create an empty one
+            open(todotxt_file_path, 'a').close()
         else:
             sys.stderr.write("ERROR: The directory: '{0}' does not exist\n".format(directory))
             sys.stderr.write("\nPlease create the directory or specify a different\n"
-                            "todo.txt file using the --file option.\n")
+                             "todo.txt file using the --file option.\n")
             exit(1)
 
     try:
@@ -50,7 +69,7 @@ def main():
             todos = Todos(todotxt_file.readlines(), todotxt_file_path)
     except:
         print("ERROR: unable to open {0}\nUse the --file option to specify a path to your todo.txt file".format(todotxt_file_path))
-        todos = todo.Todos([], todotxt_file_path)
+        todos = Todos([], todotxt_file_path)
 
     view = Screen(todos, readline_editing_mode=args.readline_editing_mode)
 


### PR DESCRIPTION
This is the first step to make todotxt-machine configurable through a file. The most important thing (for me) was to be able to set the location of the todo.txt file, since the hard-coded default didn't suit me, and I do not want to call the program with a command line parameter every time.

Using this patch, the todo.txt file must be either specified by a command line parameter, or in the configuration file `~/.todotxt_machinerc`. The command line parameter overrides any configuration setting. The configuration is a simple `.ini` style text file that can be read by Python's `ConfigParser`, which is part of the standard library, as far as I know. The current configuration file would look like this:

```
[files]
todo=~/path/to/your/todo.txt
```

Colours or custom keybindings could be the next options added to the configuration file, or the location of done.txt.
