### PR TITLE
Swap adjacent items with J/K

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Key Bindings
     O            - add a todo before the selected todo
     enter, A, e  - edit the selected todo
     D            - delete the selected todo
+    J            - swap with item below
+    K            - swap with item above
 
 ### While Editing a Todo
 

--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,8 @@ Manipulating Todo Items
     O            - add a todo before the selected todo
     enter, A, e  - edit the selected todo
     D            - delete the selected todo
+    J            - swap with item below
+    K            - swap with item above
 
 While Editing a Todo
 ~~~~~~~~~~~~~~~~~~~~

--- a/todotxt_machine/screen.py
+++ b/todotxt_machine/screen.py
@@ -284,6 +284,16 @@ class Screen:
         self.starting_item = 0
         self.selected_row = self.top_row
 
+    def swap_below(self):
+        if self.selected_item < len(self.items) - 1:
+            self.todo.swap(self.selected_item, self.selected_item + 1)
+            self.move_selection_down()
+
+    def swap_above(self):
+        if self.selected_item > 0:
+            self.todo.swap(self.selected_item, self.selected_item - 1)
+            self.move_selection_up()
+
     def select_previous_context(self):
         self.last_context = self.selected_context
         self.selected_context -= 1
@@ -457,6 +467,10 @@ class Screen:
                         self.move_selection_top()
                     elif c == "G":
                         self.move_selection_bottom()
+                    elif c == "J":
+                        self.swap_below()
+                    elif c == "K":
+                        self.swap_above()
                     elif c == "p":
                         self.select_next_project()
                     elif c == "P":

--- a/todotxt_machine/test/todo_test.py
+++ b/todotxt_machine/test/todo_test.py
@@ -397,3 +397,13 @@ def test_todos_search(todos):
     assert [t.search_matches for t in todos.search(".*")]  == [('.dinner*',)]
     assert [t.raw for t in todos.search("{b}")]            == [ "Unpack the guest {bedroom} +Unpacking due:2013-10-20" ]
     assert [t.search_matches for t in todos.search("{b}")] == [('{bedroom}',)]
+
+def test_todos_swap(todos):
+    todos.swap(0, 1)
+    assert [todo.raw_index for todo in todos.todo_items] == [1, 0, 2, 3, 4]
+    todos.swap(3, 2)
+    assert [todo.raw_index for todo in todos.todo_items] == [1, 0, 3, 2, 4]
+    todos.swap(0, -1)
+    assert [todo.raw_index for todo in todos.todo_items] == [4, 0, 3, 2, 1]
+    todos.swap(4, 5)
+    assert [todo.raw_index for todo in todos.todo_items] == [1, 0, 3, 2, 4]

--- a/todotxt_machine/todo.py
+++ b/todotxt_machine/todo.py
@@ -271,6 +271,25 @@ class Todos:
     def sorted_raw(self):
         self.todo_items.sort( key=lambda todo: todo.raw_index )
 
+    def swap(self, first, second):
+        """
+        Swap items indexed by *first* and *second*.
+
+        Out-of-bounds situations are handled by wrapping.
+        """
+        if second < first:
+            second, first = first, second
+
+        n_items = len(self.todo_items)
+
+        if first < 0:
+            first += n_items
+
+        if second >= n_items:
+            second = n_items - second
+
+        self.todo_items[first], self.todo_items[second] = self.todo_items[second], self.todo_items[first]
+
     def filter_context(self, context):
         return [item for item in self.todo_items if context in item.contexts]
 
@@ -459,4 +478,3 @@ class Todos:
     @staticmethod
     def quote():
         return Todos.quotes[ random.randrange(len(Todos.quotes)) ]
-


### PR DESCRIPTION
The change adds a new `swap` method to `todo.Todos` and binds that to J and K respectively. That effectively implements the manual reordering part of the planned features.
