### PR TITLE
Install default colorscheme

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include todotxt_machine/colors/*

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(name=NAME,
       long_description=long_description,
       keywords="todotxt, todo.txt, todo, terminal, curses, console",
       packages=find_packages(exclude=["todotxt_machine/test*"]),
+      include_package_data=True,
       entry_points={
           'console_scripts':
             ['todotxt-machine = todotxt_machine.cli:main']


### PR DESCRIPTION
I wanted to follow the recent urwid changes but couldn't run it because the default color scheme was not installed with `python setup.py install`. This change should fix that.
