### PR TITLE
Ensure save() ends file with final newline (Issue #20)

### DIFF
--- a/todotxt_machine/todo.py
+++ b/todotxt_machine/todo.py
@@ -138,7 +138,8 @@ class Todos:
 
     def save(self):
         with open(self.file_path, "w") as todotxt_file:
-            todotxt_file.write( "\n".join([t.raw for t in self.todo_items]) )
+            for t in self.todo_items:
+                todotxt_file.write(t.raw + '\n')
 
     def archive_done(self):
         if self.archive_path is not None:


### PR DESCRIPTION
A simple change to the save() method to ensure the final newline is written to file. The existing join approach leaves the final line without a newline, which is problematic when working with todo.sh, and possibly other scripts.

Just started using this - it looks great btw. Thanks!