### PR TITLE
implement edit-home and edit-end actions directly

### DIFF
--- a/todotxt_machine/urwid_ui.py
+++ b/todotxt_machine/urwid_ui.py
@@ -34,9 +34,9 @@ class AdvancedEdit(urwid.Edit):
     def keypress(self, size, key):
         # import ipdb; ipdb.set_trace()
         if self.key_bindings.is_binded_to(key, 'edit-home'):
-            key = 'home'
+            self.set_edit_pos(0)
         elif self.key_bindings.is_binded_to(key, 'edit-end'):
-            key = 'end'
+            sef.set_edit_pos(len(self.edit_text) - 1)
         elif self.key_bindings.is_binded_to(key, 'edit-delete-end'):
             self.parent_ui.yanked_text = self.edit_text[self.edit_pos:]
             self._delete_highlighted()


### PR DESCRIPTION
I just hacked around a bit and that did the trick. I'm not sure about the `len() - 1`, but it works for me, i.e. it fixes the #30 behaviour.